### PR TITLE
feat: 支持鼠标按键作为全局热键触发器

### DIFF
--- a/Services/KeyCodeMapping.cs
+++ b/Services/KeyCodeMapping.cs
@@ -196,7 +196,15 @@ namespace WpfApp.Services
             {
                 int code = (int)keyCode;
                 
-                // 检查键码范围
+                // 添加鼠标按键的验证
+                if (keyCode == DDKeyCode.MBUTTON || 
+                    keyCode == DDKeyCode.XBUTTON1 || 
+                    keyCode == DDKeyCode.XBUTTON2)
+                {
+                    return true;
+                }
+                
+                // 检查其他键码范围
                 bool isValid = code switch
                 {
                     >= 100 and <= 112 => true,   // 功能键 F1-F12
@@ -207,9 +215,10 @@ namespace WpfApp.Services
                     >= 600 and <= 607 => true,   // 控制键区
                     >= 700 and <= 712 => true,   // 编辑键区
                     >= 800 and <= 816 => true,   // 小键盘区
-                    1 or 4 or 16 or 64 or 256 => true, // 鼠标按键
+                    1 or 4 or 16 or 64 or 256 => true, // 基本鼠标按键
                     _ => false
                 };
+
                 if (!isValid)
                 {
                     _logger.LogError("KeyCodeMapping", $"无效的DD键码: {keyCode} ({code})");

--- a/ViewModels/KeyMappingViewModel.cs
+++ b/ViewModels/KeyMappingViewModel.cs
@@ -253,11 +253,27 @@ namespace WpfApp.ViewModels
                 return;
             }
 
-            _startHotkey = keyCode;
-            _startModifiers = modifiers;
-            UpdateHotkeyText(keyCode, modifiers, true);
-            _hotkeyService.RegisterStartHotkey(keyCode, modifiers);
-            _logger.LogDebug("Hotkey", $"设置开始热键: {keyCode}, 修饰键: {modifiers}");
+            try
+            {
+                _startHotkey = keyCode;
+                _startModifiers = modifiers;
+                UpdateHotkeyText(keyCode, modifiers, true);
+                
+                bool result = _hotkeyService.RegisterStartHotkey(keyCode, modifiers);
+                if (!result && !_hotkeyService.IsMouseButton(keyCode))
+                {
+                    _logger.LogError("KeyMapping", $"注册开始热键失败: {keyCode}");
+                    MessageBox.Show("开始热键注册失败，请尝试其他按键", "错误", MessageBoxButton.OK, MessageBoxImage.Warning);
+                    return;
+                }
+                
+                _logger.LogDebug("KeyMapping", $"设置开始热键: {keyCode}, 修饰键: {modifiers}");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError("KeyMapping", "设置开始热键失败", ex);
+                MessageBox.Show($"设置开始热键失败: {ex.Message}", "错误", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
         }
 
         // 更新热键显示文本

--- a/Views/KeyMappingView.xaml.cs
+++ b/Views/KeyMappingView.xaml.cs
@@ -442,6 +442,7 @@ namespace WpfApp.Views
 
                 if (keyCode.HasValue)
                 {
+                    _logger.LogDebug("HotkeyInput", $"检测到鼠标按键: {keyCode.Value}");
                     HandleHotkeyInput(textBox, keyCode.Value, Keyboard.Modifiers, true);
                     e.Handled = true; // 阻止事件继续传播
                 }
@@ -463,6 +464,7 @@ namespace WpfApp.Views
 
                 if (keyCode.HasValue)
                 {
+                    _logger.LogDebug("HotkeyInput", $"检测到鼠标按键: {keyCode.Value}");
                     HandleHotkeyInput(textBox, keyCode.Value, Keyboard.Modifiers, false);
                     e.Handled = true; // 阻止事件继续传播
                 }


### PR DESCRIPTION
# 鼠标热键支持功能

## 功能描述
添加了对鼠标中键和侧键的热键支持，使用户可以使用更多按键选项来触发快捷操作

## 主要改动
- ✨ 支持鼠标中键(Middle)作为热键
- ✨ 支持鼠标侧键(XButton1, XButton2)作为热键
- 🎨 优化了鼠标事件处理逻辑
- 📝 完善了相关日志记录

## 技术实现
- 在`DDDriverService`中增加鼠标按键支持
- 完善`KeyMappingViewModel`的热键处理机制
- 优化`KeyMappingView`中的全局鼠标事件捕获

## 测试验证
- [x] 验证鼠标中键触发功能
- [x] 验证鼠标侧键触发功能
- [x] 确认与键盘热键无冲突
- [x] 测试不同模式下的按键响应

## 关联Issue
Close #6 