### PR TITLE
fix: 修复句柄重新获取

### DIFF
--- a/Views/WindowHandleDialog.xaml
+++ b/Views/WindowHandleDialog.xaml
@@ -22,7 +22,7 @@
 
         <!-- 提示信息 -->
         <TextBlock Grid.Row="1" Margin="10,0,10,10" TextWrapping="Wrap" Foreground="#666666">
-            <Run Text="提示：选择窗口后，系统会每30秒自动枚举一次窗口类名，以确保配置信息保持最新。"/>
+            <Run Text="提示: 选择窗口后，系统会每5秒自动枚举一次窗口类名，以确保配置信息保持最新!"/>
         </TextBlock>
 
         <!-- 窗口列表 -->


### PR DESCRIPTION
修复内容：
- 句柄枚举轮询时间从30s一次改为5s一次
- 使用字段缓存窗口状态
- 先通过`GetWindowState()`、`CanTriggerHotkey()`函数检查基本条件（未选择窗口、进程未运行），再进行更耗时的窗口检查

具体逻辑：
1. 快速路径优化
- 未选择窗口时的全局触发是最快路径
- 只需要内存变量检查，无需 Win32 API 调用
2. 检查顺序优化
- 先进行内存变量检查（选择窗口、进程运行）
- 再进行 Win32 API 调用（窗口有效性、激活状态）
- 按照成本从低到高排序
3. 缓存优化
- 使用 _targetWindowHandle 缓存窗口句柄
- 避免重复获取窗口信息
4. 错误处理优化
- 每个状态都有对应的错误提示
- 异常情况下返回 WindowInvalid 状态
- 完整的日志记录